### PR TITLE
Exclude filtering on thead, enable select all on filtered list

### DIFF
--- a/cloud_browser/templates/shared/content.html
+++ b/cloud_browser/templates/shared/content.html
@@ -18,7 +18,7 @@
             $(document).ready(function(){       
                 $("#filter-input").on("keyup", function() {
                     var value = $(this).val().toLowerCase();
-                    $(".uk-table tr").filter(function() {
+                    $(".uk-table tr").not("thead tr").filter(function() {
                         $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
                     });
                 });
@@ -28,6 +28,7 @@
 
     {% block data %}
     {% endblock %}
+
 {% endblock %}
 
 {% block scripts %}

--- a/cloud_browser/templates/ssm/send_ssm_command/select_instances.html
+++ b/cloud_browser/templates/ssm/send_ssm_command/select_instances.html
@@ -37,7 +37,8 @@
             input_elements = document.getElementsByTagName('input');
 
             for (var element in input_elements) {
-                if (input_elements[element].type == 'checkbox') {
+                if (input_elements[element].type == 'checkbox' && 
+                input_elements[element].parentElement.parentElement.style['cssText'] != "display: none;") {
                     input_elements[element].checked = source.checked;
                 }
             }


### PR DESCRIPTION
Search filter function previously was hiding table headers
On ssm select_instances, enabled select all on a filtered list by ensuring their parent row doesn't have an inline style tag of "display: none;"